### PR TITLE
KP-8569 Mass upload from META-SHARE to COMEDI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Kielipankki-COMEDI Bridge
 
 This repository contains the necessary tools for transferring metadata from [META-SHARE](https://metashare.csc.fi/) to [COMEDI](https://clarino.uib.no/comedi/home).
+
+Usage help:
+```
+python send_metadata.py --help
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+click
+sickle

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+black
+pytest
+pytest-cov

--- a/send_metadata.py
+++ b/send_metadata.py
@@ -101,25 +101,37 @@ def extract_cmdi_metadata(metashare_record, modifiers):
 
 def self_link_urn_only(metashare_cmdi_record):
     """
-    Adjust the self identifier to be a plain URN, without the URL part.
+    Adjust the self identifier to be a plain URN, without the URL part. If self link is
+    not present (e.g. record creation in progress).
 
     E.g. "http://urn.fi/urn:nbn:fi:lb-123" becomes "urn:nbn:fi:lb-123".
+
     """
-    self_link_element = metashare_cmdi_record.xpath(
-        "cmd:Header/cmd:MdSelfLink", namespaces={"cmd": "http://www.clarin.eu/cmd/"}
-    )[0]
+    try:
+        self_link_element = metashare_cmdi_record.xpath(
+            "cmd:Header/cmd:MdSelfLink", namespaces={"cmd": "http://www.clarin.eu/cmd/"}
+        )[0]
+    except IndexError as err:
+        raise ParseError("Self link not found")
     self_link_element.text = self_link_element.text.split("urn.fi/")[1]
 
 
 def drop_metashare_id(metashare_cmdi_record):
     """
     Remove the metaShareId, as that has no relevance (nor relevant data) in CMDI.
+
+    If the element is not present, nothing is done.
     """
-    metashare_id_element = metashare_cmdi_record.xpath(
-        "cmd:Components/cmd:resourceInfo/cmd:identificationInfo/cmd:metaShareId",
-        namespaces={"cmd": "http://www.clarin.eu/cmd/"},
-    )[0]
-    metashare_id_element.getparent().remove(metashare_id_element)
+    try:
+        metashare_id_element = metashare_cmdi_record.xpath(
+            "cmd:Components/cmd:resourceInfo/cmd:identificationInfo/cmd:metaShareId",
+            namespaces={"cmd": "http://www.clarin.eu/cmd/"},
+        )[0]
+    except IndexError:
+        print("META-SHARE identifier not found")
+        pass
+    else:
+        metashare_id_element.getparent().remove(metashare_id_element)
 
 
 def extract_urn(metashare_record):

--- a/send_metadata.py
+++ b/send_metadata.py
@@ -111,6 +111,17 @@ def self_link_urn_only(metashare_cmdi_record):
     self_link_element.text = self_link_element.text.split("urn.fi/")[1]
 
 
+def drop_metashare_id(metashare_cmdi_record):
+    """
+    Remove the metaShareId, as that has no relevance (nor relevant data) in CMDI.
+    """
+    metashare_id_element = metashare_cmdi_record.xpath(
+        "cmd:Components/cmd:resourceInfo/cmd:identificationInfo/cmd:metaShareId",
+        namespaces={"cmd": "http://www.clarin.eu/cmd/"},
+    )[0]
+    metashare_id_element.getparent().remove(metashare_id_element)
+
+
 def extract_urn(metashare_record):
     """
     Return the unique part of the URN (e.g. "lb-1234") from META-SHARE record.
@@ -156,7 +167,7 @@ def send_metadata(comedi_session_id, metashare_api_url, comedi_upload_url, publi
 
         try:
             cmdi_data = extract_cmdi_metadata(
-                cmdi_record, modifiers=[self_link_urn_only]
+                cmdi_record, modifiers=[self_link_urn_only, drop_metashare_id]
             )
 
             urn = extract_urn(cmdi_record)

--- a/send_metadata.py
+++ b/send_metadata.py
@@ -74,8 +74,24 @@ def upload_cmdi_to_comedi(metashare_record, comedi_upload_url, session_id, publi
         print(f"Could not parse urn {urn_url}")
         return
 
-    print("TODO: upload record")
-    return
+    params = {
+        "group": "FIN-CLARIN",
+        "session-id": session_id,
+    }
+    if published:
+        params["published"] = True
+
+    response = requests.post(
+        comedi_upload_url,
+        params=params,
+        files={"file": (f"{urn}.xml", xml_content, "text/xml")},
+    )
+    response.raise_for_status()
+
+    if "error" in response.json():
+        print(f"Upload failed: {response.json()['error']}")
+    elif "success" not in response.json() or not response.json()["success"]:
+        print("Something went wrong: {response.json()}")
 
 
 @click.command()

--- a/send_metadata.py
+++ b/send_metadata.py
@@ -1,0 +1,33 @@
+import click
+
+
+def metashare_cmdi_records(metashare_api_url):
+    """
+    Iterate over all records in META-SHARE in CMDI format.
+    """
+    print("TODO: get records")
+    yield from ()
+
+
+def upload_cmdi_to_comedi(cmdi_record, comedi_upload_url):
+    """
+    Upload the given XML record to COMEDI
+    """
+    print("TODO: upload record")
+
+
+@click.command()
+@click.option("--metashare-api-url", default="https://kielipankki.fi/md_api/")
+@click.option("--comedi-upload-url", default="https://clarino.uib.no/comedi/upload")
+def send_metadata(metashare_api_url, comedi_upload_url):
+    """
+    Send all metadata from META-SHARE to COMEDI.
+    """
+    for cmdi_record in metashare_cmdi_records(metashare_api_url):
+        upload_cmdi_to_comedi(cmdi_record, comedi_upload_url)
+
+
+if __name__ == "__main__":
+    # pylint does not understand click wrappers
+    # pylint: disable=no-value-for-parameter
+    send_metadata()

--- a/send_metadata.py
+++ b/send_metadata.py
@@ -148,12 +148,29 @@ def extract_urn(metashare_record):
     return urn.strip()
 
 
+def delete_from_comedi(identifier, session_id):
+    """
+    Delete a record from COMEDI.
+    """
+    requests.get(
+        "https://clarino.uib.no/comedi/rest?command=delete-record",
+        params={"session-id": session_id, "identifier": identifier},
+    )
+
+
 @click.command()
 @click.argument("comedi_session_id")
 @click.option("--metashare-api-url", default="https://kielipankki.fi/md_api/que")
 @click.option("--comedi-upload-url", default="https://clarino.uib.no/comedi/upload")
 @click.option("--publish/--unpublish", default=False)
-def send_metadata(comedi_session_id, metashare_api_url, comedi_upload_url, publish):
+@click.option("--delete-before-upload", default=False, is_flag=True)
+def send_metadata(
+    comedi_session_id,
+    metashare_api_url,
+    comedi_upload_url,
+    publish,
+    delete_before_upload,
+):
     """
     Send all metadata from META-SHARE to COMEDI.
     """
@@ -178,6 +195,9 @@ def send_metadata(comedi_session_id, metashare_api_url, comedi_upload_url, publi
             )
             failed_records += 1
             continue
+
+        if delete_before_upload:
+            delete_from_comedi(urn, comedi_session_id)
 
         try:
             upload_cmdi_to_comedi(

--- a/send_metadata.py
+++ b/send_metadata.py
@@ -1,30 +1,102 @@
+import requests
+
 import click
+import lxml
+from sickle import Sickle, oaiexceptions
 
 
 def metashare_cmdi_records(metashare_api_url):
     """
     Iterate over all records in META-SHARE in CMDI format.
     """
-    print("TODO: get records")
-    yield from ()
+    sickle = Sickle(metashare_api_url)
+    metadata_records = sickle.ListIdentifiers(
+        **{
+            "metadataPrefix": "info",
+            "ignore_deleted": True,
+        }
+    )
+    for record in metadata_records:
+        for metadata_format in ["cmdi0554", "cmdi0571", "cmdi2312", "cmdi9836"]:
+            try:
+                response = sickle.GetRecord(
+                    identifier=record.identifier, metadataPrefix=metadata_format
+                )
+            except oaiexceptions.CannotDisseminateFormat:
+                continue
+            print(record.identifier)
+            yield response.xml
+            break
 
 
-def upload_cmdi_to_comedi(cmdi_record, comedi_upload_url):
+def upload_cmdi_to_comedi(metashare_record, comedi_upload_url, session_id, published):
     """
     Upload the given XML record to COMEDI
+
+    In case of errors, a message is printed to stdout and the problematic record is
+    skipped.
     """
+    try:
+        cmdi_record = metashare_record.xpath(
+            "oai:metadata/cmd:CMD",
+            namespaces={
+                "oai": "http://www.openarchives.org/OAI/2.0/",
+                "cmd": "http://www.clarin.eu/cmd/",
+            },
+        )[0]
+        xml_content = lxml.etree.tostring(
+            cmdi_record, xml_declaration=True, encoding="utf-8"
+        )
+    except IndexError:
+        metashare_identifier = metashare_record.xpath(
+            "oai:header/oai:identifier/text()",
+            namespaces={"oai": "http://www.openarchives.org/OAI/2.0/"},
+        )[0]
+        print(f"No CMDI record found for {metashare_identifier}")
+        return
+
+    try:
+        urn_url = cmdi_record.xpath(
+            "cmd:Components/cmd:resourceInfo/cmd:identificationInfo/cmd:identifier/text()",
+            namespaces={"cmd": "http://www.clarin.eu/cmd/"},
+        )[0]
+    except IndexError:
+        metashare_identifier = metashare_record.xpath(
+            "oai:header/oai:identifier/text()",
+            namespaces={"oai": "http://www.openarchives.org/OAI/2.0/"},
+        )[0]
+        print(f"No urn found for {metashare_identifier}")
+        return
+
+    try:
+        urn = urn_url.split("urn:nbn:fi:")[1]
+    except IndexError:
+        print(f"Could not parse urn {urn_url}")
+        return
+
     print("TODO: upload record")
+    return
 
 
 @click.command()
-@click.option("--metashare-api-url", default="https://kielipankki.fi/md_api/")
+@click.argument("comedi_session_id")
+@click.option("--metashare-api-url", default="https://kielipankki.fi/md_api/que")
 @click.option("--comedi-upload-url", default="https://clarino.uib.no/comedi/upload")
-def send_metadata(metashare_api_url, comedi_upload_url):
+@click.option("--publish/--unpublish", default=False)
+def send_metadata(comedi_session_id, metashare_api_url, comedi_upload_url, publish):
     """
     Send all metadata from META-SHARE to COMEDI.
     """
+    records = 0
     for cmdi_record in metashare_cmdi_records(metashare_api_url):
-        upload_cmdi_to_comedi(cmdi_record, comedi_upload_url)
+        records += 1
+        upload_cmdi_to_comedi(
+            cmdi_record,
+            comedi_upload_url,
+            session_id=comedi_session_id,
+            published=publish,
+        )
+    print(f"{records} processed")
 
 
 if __name__ == "__main__":

--- a/send_metadata.py
+++ b/send_metadata.py
@@ -92,6 +92,9 @@ def extract_cmdi_metadata(metashare_record):
 def extract_urn(metashare_record):
     """
     Return the unique part of the URN (e.g. "lb-1234") from META-SHARE record.
+
+    Unfortunately some of our URNs have trailing whitespace (e.g. "lb-1234 "): that is
+    not allowed in COMEDI identifiers, so whitespace is stripped.
     """
     try:
         urn_url = metashare_record.xpath(
@@ -109,7 +112,7 @@ def extract_urn(metashare_record):
     except IndexError:
         raise ParseError(f"Could not parse urn {urn_url}")
 
-    return urn
+    return urn.strip()
 
 
 @click.command()

--- a/send_metadata.py
+++ b/send_metadata.py
@@ -116,24 +116,6 @@ def self_link_urn_only(metashare_cmdi_record):
     self_link_element.text = self_link_element.text.split("urn.fi/")[1]
 
 
-def drop_metashare_id(metashare_cmdi_record):
-    """
-    Remove the metaShareId, as that has no relevance (nor relevant data) in CMDI.
-
-    If the element is not present, nothing is done.
-    """
-    try:
-        metashare_id_element = metashare_cmdi_record.xpath(
-            "cmd:Components/cmd:resourceInfo/cmd:identificationInfo/cmd:metaShareId",
-            namespaces={"cmd": "http://www.clarin.eu/cmd/"},
-        )[0]
-    except IndexError:
-        print("META-SHARE identifier not found")
-        pass
-    else:
-        metashare_id_element.getparent().remove(metashare_id_element)
-
-
 def extract_urn(metashare_record):
     """
     Return the unique part of the URN (e.g. "lb-1234") from META-SHARE record.
@@ -196,7 +178,7 @@ def send_metadata(
 
         try:
             cmdi_data = extract_cmdi_metadata(
-                cmdi_record, modifiers=[self_link_urn_only, drop_metashare_id]
+                cmdi_record, modifiers=[self_link_urn_only]
             )
 
             urn = extract_urn(cmdi_record)


### PR DESCRIPTION
Added command line tool for uploading all records from META-SHARE to COMEDI. This is likely to be somewhat single-use code, so it isn't organized very carefully and there's no automatic testing.

The records uploaded by this code can be viewed at https://clarino.uib.no/comedi/records by searching for records owned by Anni Järvenpää.